### PR TITLE
Fix: Enable model monitoring

### DIFF
--- a/pipelines/src/pipelines/tensorflow/prediction/pipeline.py
+++ b/pipelines/src/pipelines/tensorflow/prediction/pipeline.py
@@ -108,12 +108,16 @@ def tensorflow_pipeline(
     ).set_display_name("Ingest data")
 
     # lookup champion model
-    champion_model = lookup_model(
-        model_name=model_name,
-        project_location=project_location,
-        project_id=project_id,
-        fail_on_model_not_found=True,
-    ).set_display_name("Look up champion model")
+    champion_model = (
+        lookup_model(
+            model_name=model_name,
+            project_location=project_location,
+            project_id=project_id,
+            fail_on_model_not_found=True,
+        )
+        .set_display_name("Look up champion model")
+        .set_caching_options(False)
+    )
 
     # batch predict from BigQuery to BigQuery
     bigquery_source_input_uri = f"bq://{project_id}.{dataset_id}.{ingested_table}"

--- a/pipelines/src/pipelines/tensorflow/training/pipeline.py
+++ b/pipelines/src/pipelines/tensorflow/training/pipeline.py
@@ -215,6 +215,7 @@ def tensorflow_pipeline(
             fail_on_model_not_found=False,
         )
         .set_display_name("Lookup past model")
+        .set_caching_options(False)
         .outputs["model_resource_name"]
     )
 

--- a/pipelines/src/pipelines/xgboost/prediction/pipeline.py
+++ b/pipelines/src/pipelines/xgboost/prediction/pipeline.py
@@ -102,12 +102,16 @@ def xgboost_pipeline(
     ).set_display_name("Ingest data")
 
     # lookup champion model
-    champion_model = lookup_model(
-        model_name=model_name,
-        project_location=project_location,
-        project_id=project_id,
-        fail_on_model_not_found=True,
-    ).set_display_name("Look up champion model")
+    champion_model = (
+        lookup_model(
+            model_name=model_name,
+            project_location=project_location,
+            project_id=project_id,
+            fail_on_model_not_found=True,
+        )
+        .set_display_name("Look up champion model")
+        .set_caching_options(False)
+    )
 
     # batch predict from BigQuery to BigQuery
     bigquery_source_input_uri = f"bq://{project_id}.{dataset_id}.{ingested_table}"

--- a/pipelines/src/pipelines/xgboost/training/pipeline.py
+++ b/pipelines/src/pipelines/xgboost/training/pipeline.py
@@ -212,6 +212,7 @@ def xgboost_pipeline(
             fail_on_model_not_found=False,
         )
         .set_display_name("Lookup past model")
+        .set_caching_options(False)
         .outputs["model_resource_name"]
     )
 


### PR DESCRIPTION
# Description

Model monitoring metadata isn't persisted during XGBoost training. Further, caching has been disabled for `lookup_model` components in all pipelines.

# How has this been tested?

- clean model registry
- end-to-end tests (with and without caching)
- ensure that batch prediction jobs return monitoring results

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have successfully run the E2E tests, and have included the links to the pipeline runs below
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated any relevant documentation to reflect my changes
- [x] I have assigned a reviewer and messaged them

# Pipeline run links:
