### PR TITLE
feat: return gcp resources

### DIFF
--- a/components/vertex-components/src/vertex_components/custom_train_job.py
+++ b/components/vertex-components/src/vertex_components/custom_train_job.py
@@ -87,6 +87,7 @@ def custom_train_job(
     Returns:
         parent_model (str): Resource URI of the parent model (empty string if the
             trained model is the first model version of its kind).
+        NamedTuple: gcp_resources for Vertex AI UI integration.
     """
     import json
     import logging
@@ -146,18 +147,10 @@ def custom_train_job(
         if type(v) is float:
             metrics.log_metric(k, v)
     
-    custom_train_job_name = job.name
-    logging.info(f"CustomJobName: {job.name }")
-
+    # return GCP resource for Vertex AI UI integration
     custom_train_job_resources = GcpResources()
     ctr = custom_train_job_resources.resources.add()
-    ctr.resource_type = "CustomJob"
-    ctr.resource_uri=f"https://{project_location}-aiplatform.googleapis.com/v1/projects/{project_id}/locations/{project_location}/customJobs/{custom_train_job_name}"
-    # ctr.resource_uri=f"https://{project_location}-aiplatform.googleapis.com/v1/projects/{project_id}/locations/{project_location}/trainingPipelines/{custom_train_job_name}" ?
-
+    ctr.resource_type = "CustomTrainingJob"
+    ctr.resource_uri=f"https://{project_location}-aiplatform.googleapis.com/v1/{job.resource_name}"
     gcp_resources=MessageToJson(custom_train_job_resources)
-    logging.info(f"GCPresources -: {gcp_resources }")
-    return gcp_resources
-
-    # return NamedTuple("Outputs", [("gcp_resources", str)])(gcp_resources) ?
-
+    return (gcp_resources,)

--- a/components/vertex-components/src/vertex_components/custom_train_job.py
+++ b/components/vertex-components/src/vertex_components/custom_train_job.py
@@ -147,10 +147,12 @@ def custom_train_job(
         if type(v) is float:
             metrics.log_metric(k, v)
     
+
     # return GCP resource for Vertex AI UI integration
+    custom_job_name = job.to_dict()['trainingTaskMetadata']['backingCustomJob']
     custom_train_job_resources = GcpResources()
     ctr = custom_train_job_resources.resources.add()
     ctr.resource_type = "CustomJob"
-    ctr.resource_uri=f"https://{project_location}-aiplatform.googleapis.com/v1/projects/{project_id}/locations/{project_location}/customJobs/{job.name}"
+    ctr.resource_uri=custom_job_name
     gcp_resources=MessageToJson(custom_train_job_resources)
     return (gcp_resources,)

--- a/components/vertex-components/src/vertex_components/custom_train_job.py
+++ b/components/vertex-components/src/vertex_components/custom_train_job.py
@@ -150,7 +150,7 @@ def custom_train_job(
     # return GCP resource for Vertex AI UI integration
     custom_train_job_resources = GcpResources()
     ctr = custom_train_job_resources.resources.add()
-    ctr.resource_type = "CustomTrainingJob"
-    ctr.resource_uri=f"https://{project_location}-aiplatform.googleapis.com/v1/{job.resource_name}"
+    ctr.resource_type = "CustomJob"
+    ctr.resource_uri=f"https://{project_location}-aiplatform.googleapis.com/v1/projects/{project_id}/locations/{project_location}/customJobs/{job.name}"
     gcp_resources=MessageToJson(custom_train_job_resources)
     return (gcp_resources,)

--- a/components/vertex-components/src/vertex_components/custom_train_job.py
+++ b/components/vertex-components/src/vertex_components/custom_train_job.py
@@ -18,7 +18,10 @@ from kfp.v2.dsl import Input, component, Metrics, Output, Artifact, Dataset
 
 @component(
     base_image="python:3.7",
-    packages_to_install=["google-cloud-aiplatform==1.24.1", "google-cloud-pipeline-components==1.0.42"],
+    packages_to_install=[
+        "google-cloud-aiplatform==1.24.1",
+        "google-cloud-pipeline-components==1.0.42",
+    ],
 )
 def custom_train_job(
     train_script_uri: str,
@@ -41,7 +44,7 @@ def custom_train_job(
     accelerator_type: str = "ACCELERATOR_TYPE_UNSPECIFIED",
     accelerator_count: int = 0,
     parent_model: str = None,
-) -> NamedTuple("Outputs",  [("gcp_resources", str)]):
+) -> NamedTuple("Outputs", [("gcp_resources", str)]):
     """Run a custom training job using a training script.
 
     The provided script will be invoked by passing the following command-line arguments:
@@ -146,13 +149,12 @@ def custom_train_job(
     for k, v in parsed_metrics.items():
         if type(v) is float:
             metrics.log_metric(k, v)
-    
 
     # return GCP resource for Vertex AI UI integration
-    custom_job_name = job.to_dict()['trainingTaskMetadata']['backingCustomJob']
+    custom_job_name = job.to_dict()["trainingTaskMetadata"]["backingCustomJob"]
     custom_train_job_resources = GcpResources()
     ctr = custom_train_job_resources.resources.add()
     ctr.resource_type = "CustomJob"
-    ctr.resource_uri=custom_job_name
-    gcp_resources=MessageToJson(custom_train_job_resources)
+    ctr.resource_uri = custom_job_name
+    gcp_resources = MessageToJson(custom_train_job_resources)
     return (gcp_resources,)

--- a/components/vertex-components/src/vertex_components/custom_train_job.py
+++ b/components/vertex-components/src/vertex_components/custom_train_job.py
@@ -1,5 +1,5 @@
 # Copyright 2022 Google LLC
-from typing import List, Dict
+from typing import List, Dict, NamedTuple
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ from kfp.v2.dsl import Input, component, Metrics, Output, Artifact, Dataset
 
 @component(
     base_image="python:3.7",
-    packages_to_install=["google-cloud-aiplatform==1.24.1"],
+    packages_to_install=["google-cloud-aiplatform==1.24.1", "google-cloud-pipeline-components==1.0.42"],
 )
 def custom_train_job(
     train_script_uri: str,
@@ -41,7 +41,7 @@ def custom_train_job(
     accelerator_type: str = "ACCELERATOR_TYPE_UNSPECIFIED",
     accelerator_count: int = 0,
     parent_model: str = None,
-):
+) -> NamedTuple("Outputs",  [("gcp_resources", str)]):
     """Run a custom training job using a training script.
 
     The provided script will be invoked by passing the following command-line arguments:
@@ -93,6 +93,8 @@ def custom_train_job(
     import os.path
     import time
     import google.cloud.aiplatform as aip
+    from google_cloud_pipeline_components.proto.gcp_resources_pb2 import GcpResources
+    from google.protobuf.json_format import MessageToJson
 
     logging.info(f"Using train script: {train_script_uri}")
     script_path = "/gcs/" + train_script_uri[5:]
@@ -143,3 +145,19 @@ def custom_train_job(
     for k, v in parsed_metrics.items():
         if type(v) is float:
             metrics.log_metric(k, v)
+    
+    custom_train_job_name = job.name
+    logging.info(f"CustomJobName: {job.name }")
+
+    custom_train_job_resources = GcpResources()
+    ctr = custom_train_job_resources.resources.add()
+    ctr.resource_type = "CustomJob"
+    ctr.resource_uri=f"https://{project_location}-aiplatform.googleapis.com/v1/projects/{project_id}/locations/{project_location}/customJobs/{custom_train_job_name}"
+    # ctr.resource_uri=f"https://{project_location}-aiplatform.googleapis.com/v1/projects/{project_id}/locations/{project_location}/trainingPipelines/{custom_train_job_name}" ?
+
+    gcp_resources=MessageToJson(custom_train_job_resources)
+    logging.info(f"GCPresources -: {gcp_resources }")
+    return gcp_resources
+
+    # return NamedTuple("Outputs", [("gcp_resources", str)])(gcp_resources) ?
+


### PR DESCRIPTION
<!-- 
Copyright 2022 Google LLC

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    https://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
 -->
# Description

Return gcp_resources in custom_train_job. Should allow to click "view custom job" in UI.
Relevant documentation: https://cloud.google.com/vertex-ai/docs/pipelines/build-own-components
![image](https://github.com/teamdatatonic/vertex-pipelines-end-to-end-samples/assets/125287387/e3bb677f-cec1-4842-a79e-1de9b5023fb5)

# How has this been tested?

make e2e-tests
make test-all-components
Tests in CICD

# Checklist

- [X] I have commented my code, particularly in hard-to-understand areas
- [x] I have successfully run the E2E tests, and have included the links to the pipeline runs below
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated any relevant documentation to reflect my changes
- [ ] I have assigned a reviewer and messaged them

# Pipeline run links:
https://console.cloud.google.com/vertex-ai/locations/europe-west2/pipelines/runs/tensorflow-prediction-pipeline-20230602085628?project=dt-turbo-templates-staging
https://console.cloud.google.com/vertex-ai/locations/europe-west2/pipelines/runs/xgboost-prediction-pipeline-20230602084746?project=dt-turbo-templates-staging
https://console.cloud.google.com/vertex-ai/locations/europe-west2/pipelines/runs/tensorflow-train-pipeline-20230602083603?project=dt-turbo-templates-staging
https://console.cloud.google.com/vertex-ai/locations/europe-west2/pipelines/runs/xgboost-train-pipeline-20230602083557?project=dt-turbo-templates-staging