### PR TITLE
Fix duplicated logs when running a pipeline

### DIFF
--- a/pipelines/src/pipelines/trigger/main.py
+++ b/pipelines/src/pipelines/trigger/main.py
@@ -15,7 +15,6 @@
 import argparse
 import base64
 import json
-import logging
 import os
 import distutils.util
 from typing import Optional, List
@@ -191,10 +190,6 @@ def sandbox_run(args: List[str] = None) -> aiplatform.PipelineJob:
     Returns the PipelineJob object of the triggered pipeline run.
     Usage: python main.py --template_path=pipeline.json --enable_caching=true
     """
-    logger = logging.getLogger(__name__)
-    logger.setLevel(logging.DEBUG)
-    logger.debug("This is a debug message")
-
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--template_path", help="Path to the compiled pipeline (JSON)", type=str

--- a/pipelines/src/pipelines/trigger/main.py
+++ b/pipelines/src/pipelines/trigger/main.py
@@ -191,7 +191,9 @@ def sandbox_run(args: List[str] = None) -> aiplatform.PipelineJob:
     Returns the PipelineJob object of the triggered pipeline run.
     Usage: python main.py --template_path=pipeline.json --enable_caching=true
     """
-    logging.basicConfig(level=logging.DEBUG)
+    logger = logging.getLogger(__name__)
+    logger.setLevel(logging.DEBUG)
+    logger.debug("This is a debug message")
 
     parser = argparse.ArgumentParser()
     parser.add_argument(


### PR DESCRIPTION
# Description

## 1. Bug description 

When we try to run a pipeline, for example `make run pipeline=training`, we noticed that there are duplicated lines of log showing up 

![image](https://github.com/teamdatatonic/vertex-pipelines-end-to-end-samples/assets/130454458/34dca2f6-5a04-4f03-aac3-a1df9fff880c)


## 2. Root cause analysis

In google.cloud/aiplatform modules:

base.py: lib/python3.7/site-packages/google/cloud/aiplatform/base.py 

```python
class Logger:
    ...
        self._logger.setLevel(logging.INFO)
```

pipeline_jobs.py: lib/python3.7/site-packages/google/cloud/aiplatform/pipeline_jobs.py 

```python
#line 48
_LOGGER = base.Logger(__name__)

#line 430
_LOGGER.info("View Pipeline Job:\n%s" % self._dashboard_uri())
```

In pipelines modules:

[main.py](https://github.com/teamdatatonic/vertex-pipelines-end-to-end-samples/blob/47cf5d69ee014099c3624505b323680ccca85274/pipelines/src/pipelines/trigger/main.py#L194C4-L194C4): pipelines/trigger/main.py

```python
#line 194
logging.basicConfig(level=logging.DEBUG)
```

When a base function has already set the logging level to `logging.INFO` and a child function calls `logging.basicConfig(level=logging.DEBUG)`, it causes duplicated log entries with both `INFO` and `DEBUG` levels. This is because `basicConfig` configures the root logger, so the child function's call to `basicConfig` will not affect the already-configured logger in the base function. As a result, any log entries generated in the base function with `INFO` level will still be logged even if the child function has set the level to `DEBUG`.

To avoid this issue, it is recommended to configure logging only once at the start of the program and avoid calling `basicConfig` in child functions. This ensures that all loggers share the same configurations and prevent duplicated logs with different levels. In addition, it is important to choose an appropriate logging level for each module or function to ensure that the logs are relevant and not too verbose. 

In order to set the logging level to `DEBUG` in the child function (sandbox_run) without causing duplicated logs with `INFO` level from the base function, we can create a logger instance in the child function and set its logging level to `DEBUG`. For example:

```
import logging

def sandbox_run(args: List[str] = None) -> aiplatform.PipelineJob:

    logger = logging.getLogger(__name__)
    logger.setLevel(logging.DEBUG)
    logger.debug('This is a debug message')

```
# How has this been tested?

- `make test-all-components`
- `make run pipeline=training`
Logs are no longer duplicated
<img width="919" alt="image" src="https://github.com/teamdatatonic/vertex-pipelines-end-to-end-samples/assets/130454458/ea1d159a-c2dd-44b1-a286-e5f1d9827c91">


- `make run pipeline=prediction`
<img width="656" alt="image" src="https://github.com/teamdatatonic/vertex-pipelines-end-to-end-samples/assets/130454458/d8654a96-7411-4aa6-914e-59a7328e7b68">


# Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have successfully run the E2E tests, and have included the links to the pipeline runs below
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated any relevant documentation to reflect my changes
- [ ] I have assigned a reviewer and messaged them

# Pipeline run links:
