### PR TITLE
Reduce size of model containers

### DIFF
--- a/model/Dockerfile
+++ b/model/Dockerfile
@@ -15,23 +15,23 @@ FROM python:3.9.16-slim AS builder
 
 ENV PIP_NO_CACHE_DIR=off \
     PIP_DISABLE_PIP_VERSION_CHECK=on \
-    PIP_DEFAULT_TIMEOUT=100
+    PIP_DEFAULT_TIMEOUT=100 \
+    POETRY_VIRTUALENVS_CREATE=false
 
 ARG POETRY_VERSION=1.5.1
-
-COPY pyproject.toml pyproject.toml
-COPY poetry.lock poetry.lock
-
 RUN pip install poetry==${POETRY_VERSION}
-RUN poetry config virtualenvs.create false && poetry install
+COPY pyproject.toml poetry.lock .
 
 FROM builder AS training
 
+RUN poetry install --no-cache --no-interaction --without prediction
 COPY training training
+
+CMD python -m training
 
 FROM builder AS prediction
 
-RUN poetry install --with prediction
+RUN poetry install --no-cache --no-interaction --with prediction
 COPY prediction prediction
 
 CMD exec uvicorn prediction.main:app --host "0.0.0.0" --port "$AIP_HTTP_PORT"


### PR DESCRIPTION
<!-- 
Copyright 2023 Google LLC

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    https://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
 -->
# Description

Update `model/Dockerfile` to not persist cached Pypi packages. This reduces training and prediction images by 300MB.

# How has this been tested?

- `docker build`
- `docker run`

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`make test-trigger` and `make test-all-components`)
- [x] I have successfully run the E2E tests
- [x] I have updated any relevant documentation to reflect my changes
