### PR TITLE
Scheduler api

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,31 @@ gcloud auth login
 gcloud auth application-default login
 ```
 
+## Configure Pipeline Variables
+
+Before running pipelines, update [`pipelines/variables/variables.yml`](pipelines/variables/variables.yml) with your Google Cloud project IDs:
+
+```yaml
+vertex_project_dev: "my-gcp-project-dev"
+vertex_project_staging: "my-gcp-project-staging"
+vertex_project_prod: "my-gcp-project-prod"
+```
+
+These values are used to detect which environment the pipeline is running in. When a pipeline is triggered, the `VERTEX_PROJECT_ID` environment variable (set in `env.sh`) is matched against these entries to load the correct environment-specific configuration.
+
+### Pipeline Scheduling
+
+Each environment (`dev`, `staging`, `prod`) has its own scheduler configuration in `variables.yml`. When a training or prediction pipeline is triggered, the scheduler config for the current environment is loaded and used to create or remove a Vertex AI pipeline schedule via the [`PipelineJobSchedule`](https://cloud.google.com/vertex-ai/docs/pipelines/schedule-pipeline-run) API.
+
+| Setting | Description |
+|---------|-------------|
+| `enable_training_scheduler` / `enable_prediction_scheduler` | Set to `true` to create a schedule, `false` to remove any existing one |
+| `training_cron` / `prediction_cron` | Cron expression for the schedule (see [crontab.guru](https://crontab.guru/)) |
+| `training_max_concurrent_run_count` / `prediction_max_concurrent_run_count` | Max number of pipeline runs that can execute concurrently |
+| `training_max_run_count` / `prediction_max_run_count` | Total number of runs before the schedule is paused (`0` for infinite) |
+
+When scheduling is enabled, any previous schedule for that pipeline type is automatically deleted before creating the new one, ensuring only one active schedule exists at a time.
+
 ## Run
 
 This repository contains example ML training and prediction pipelines which are explained in [this guide](docs/Pipelines.md).

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ vertex_project_staging: "my-gcp-project-staging"
 vertex_project_prod: "my-gcp-project-prod"
 ```
 
-These values are used to detect which environment the pipeline is running in. When a pipeline is triggered, the `VERTEX_PROJECT_ID` environment variable (set in `env.sh`) is matched against these entries to load the correct environment-specific configuration.
+These values are used to detect which environment the pipeline is running in. When a pipeline is triggered, the `VERTEX_PROJECT_ID` environment variable (set in `env.sh`) is matched against these entries to load the correct environment-specific configuration. If `VERTEX_PROJECT_ID` does not match any of the configured project IDs, scheduling is skipped and the pipeline is submitted without creating or modifying any schedules.
 
 ### Pipeline Scheduling
 

--- a/pipelines/src/pipelines/utils/load_config.py
+++ b/pipelines/src/pipelines/utils/load_config.py
@@ -23,20 +23,23 @@ import yaml
 _ENVIRONMENTS = ("dev", "staging", "prod")
 
 
-def detect_environment(config: dict) -> str:
-    """Match VERTEX_PROJECT_ID against vertex_project_* values in config."""
+def detect_environment(config: dict) -> str | None:
+    """Match VERTEX_PROJECT_ID against vertex_project_* values in config.
+
+    Returns None if no matching entry is found.
+    """
     project_id = os.environ.get("VERTEX_PROJECT_ID", "")
     for env in _ENVIRONMENTS:
         if config.get(f"vertex_project_{env}") == project_id:
             return env
-    raise ValueError(
-        f"Could not detect environment from VERTEX_PROJECT_ID='{project_id}'. "
-        f"No matching vertex_project_* entry found in variables.yml."
-    )
+    return None
 
 
-def load_variables() -> dict:
-    """Load variables.yml and return the block for the current environment."""
+def load_variables() -> dict | None:
+    """Load variables.yml and return the block for the current environment.
+
+    Returns None if VERTEX_PROJECT_ID does not match any configured project.
+    """
     config_path = (
         pathlib.Path(__file__).parent.parent.parent.parent
         / "variables"
@@ -46,4 +49,6 @@ def load_variables() -> dict:
         config = yaml.safe_load(f)
 
     environment = detect_environment(config)
+    if environment is None:
+        return None
     return config.get(environment, {})

--- a/pipelines/src/pipelines/utils/load_config.py
+++ b/pipelines/src/pipelines/utils/load_config.py
@@ -1,0 +1,49 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Load per-environment configuration from variables.yml."""
+
+import os
+import pathlib
+
+import yaml
+
+
+_ENVIRONMENTS = ("dev", "staging", "prod")
+
+
+def detect_environment(config: dict) -> str:
+    """Match VERTEX_PROJECT_ID against vertex_project_* values in config."""
+    project_id = os.environ.get("VERTEX_PROJECT_ID", "")
+    for env in _ENVIRONMENTS:
+        if config.get(f"vertex_project_{env}") == project_id:
+            return env
+    raise ValueError(
+        f"Could not detect environment from VERTEX_PROJECT_ID='{project_id}'. "
+        f"No matching vertex_project_* entry found in variables.yml."
+    )
+
+
+def load_variables() -> dict:
+    """Load variables.yml and return the block for the current environment."""
+    config_path = (
+        pathlib.Path(__file__).parent.parent.parent.parent
+        / "variables"
+        / "variables.yml"
+    )
+    with open(config_path) as f:
+        config = yaml.safe_load(f)
+
+    environment = detect_environment(config)
+    return config.get(environment, {})

--- a/pipelines/src/pipelines/utils/trigger_pipeline.py
+++ b/pipelines/src/pipelines/utils/trigger_pipeline.py
@@ -146,9 +146,9 @@ def trigger_pipeline(
     )
 
     env_vars = load_variables()
-    scheduler_config = env_vars.get("scheduler", {})
+    scheduler_config = env_vars.get("scheduler", {}) if env_vars else {}
 
-    if display_name in ("training", "prediction"):
+    if scheduler_config and display_name in ("training", "prediction"):
         _handle_schedule(
             display_name,
             scheduler_config,

--- a/pipelines/src/pipelines/utils/trigger_pipeline.py
+++ b/pipelines/src/pipelines/utils/trigger_pipeline.py
@@ -14,7 +14,89 @@
 
 import argparse
 import os
+
 from google.cloud import aiplatform
+
+from pipelines.utils.load_config import load_variables
+
+
+def delete_previous_schedules(
+    schedule_pipeline_name: str, project_id: str, location: str
+):
+    """
+    Deletes all previous schedules matching the given display name.
+    Ensures only one schedule exists per pipeline type.
+    """
+    all_schedules = aiplatform.PipelineJobSchedule.list(
+        project=project_id,
+        location=location,
+    )
+    for scheduled_job in all_schedules:
+        print(f"Checking schedule: {scheduled_job.display_name}")
+        if schedule_pipeline_name == scheduled_job.display_name:
+            print(f"Deleting schedule: {scheduled_job.display_name}")
+            scheduled_job.delete()
+
+
+def _handle_schedule(
+    display_name: str,
+    scheduler_config: dict,
+    pl: aiplatform.PipelineJob,
+    project_id: str,
+    location: str,
+    service_account: str,
+    network: str,
+    pipeline_root: str,
+    template_path: str,
+    encryption_spec_key_name: str,
+):
+    """Create or delete a schedule for the given pipeline type."""
+    if display_name == "training":
+        schedule_name = "training_pipeline"
+        enabled = scheduler_config.get("enable_training_scheduler") is True
+        cron = scheduler_config.get("training_cron")
+        max_concurrent = scheduler_config.get(
+            "training_max_concurrent_run_count", 1
+        )
+        max_runs = scheduler_config.get("training_max_run_count", 0)
+    else:
+        schedule_name = "prediction_pipeline"
+        enabled = scheduler_config.get("enable_prediction_scheduler") is True
+        cron = scheduler_config.get("prediction_cron")
+        max_concurrent = scheduler_config.get(
+            "prediction_max_concurrent_run_count", 1
+        )
+        max_runs = scheduler_config.get("prediction_max_run_count", 0)
+
+    if enabled and cron:
+        delete_previous_schedules(schedule_name, project_id, location)
+
+        scheduled_pl = aiplatform.PipelineJob(
+            project=project_id,
+            location=location,
+            display_name=display_name,
+            enable_caching=False,
+            template_path=template_path,
+            pipeline_root=pipeline_root,
+            encryption_spec_key_name=encryption_spec_key_name,
+        )
+
+        print(f"Creating {display_name} pipeline schedule (caching disabled)")
+        scheduled_pl.create_schedule(
+            display_name=schedule_name,
+            cron=cron,
+            max_concurrent_run_count=max_concurrent,
+            max_run_count=max_runs if max_runs != 0 else None,
+            service_account=service_account,
+            network=network,
+        )
+        print(f"Successfully created {display_name} pipeline schedule")
+    else:
+        print(
+            f"{display_name.capitalize()} scheduler disabled, "
+            "removing any existing schedules"
+        )
+        delete_previous_schedules(schedule_name, project_id, location)
 
 
 def trigger_pipeline(
@@ -61,6 +143,22 @@ def trigger_pipeline(
         template_path=template_path,
         pipeline_root=pipeline_root,
         encryption_spec_key_name=encryption_spec_key_name,
+    )
+
+    env_vars = load_variables()
+    scheduler_config = env_vars.get("scheduler", {})
+
+    _handle_schedule(
+        display_name,
+        scheduler_config,
+        pl,
+        project_id,
+        location,
+        service_account,
+        network,
+        pipeline_root,
+        template_path,
+        encryption_spec_key_name,
     )
 
     # Execute pipeline in Vertex

--- a/pipelines/src/pipelines/utils/trigger_pipeline.py
+++ b/pipelines/src/pipelines/utils/trigger_pipeline.py
@@ -148,18 +148,19 @@ def trigger_pipeline(
     env_vars = load_variables()
     scheduler_config = env_vars.get("scheduler", {})
 
-    _handle_schedule(
-        display_name,
-        scheduler_config,
-        pl,
-        project_id,
-        location,
-        service_account,
-        network,
-        pipeline_root,
-        template_path,
-        encryption_spec_key_name,
-    )
+    if display_name in ("training", "prediction"):
+        _handle_schedule(
+            display_name,
+            scheduler_config,
+            pl,
+            project_id,
+            location,
+            service_account,
+            network,
+            pipeline_root,
+            template_path,
+            encryption_spec_key_name,
+        )
 
     # Execute pipeline in Vertex
     pl.submit(

--- a/pipelines/tests/utils/test_trigger_pipeline.py
+++ b/pipelines/tests/utils/test_trigger_pipeline.py
@@ -33,9 +33,11 @@ from pipelines.utils.trigger_pipeline import trigger_pipeline
         (None, None),  # ENABLE_PIPELINE_CACHING env var not set
     ],
 )
+@mock.patch("pipelines.utils.trigger_pipeline.load_variables", return_value={})
 @mock.patch("google.cloud.aiplatform.PipelineJob")
 def test_trigger_pipeline(
-    mock_pipelinejob, test_enable_caching_input, enable_caching_expected
+    mock_pipelinejob, mock_load_variables, test_enable_caching_input,
+    enable_caching_expected,
 ):
 
     template_path = "path/to/template.yaml"
@@ -83,8 +85,11 @@ def test_trigger_pipeline(
         )
 
 
+@mock.patch("pipelines.utils.trigger_pipeline.load_variables", return_value={})
 @mock.patch("google.cloud.aiplatform.PipelineJob")
-def test_trigger_pipeline_invalid_caching_env_var(mock_pipelinejob):
+def test_trigger_pipeline_invalid_caching_env_var(
+    mock_pipelinejob, mock_load_variables,
+):
 
     template_path = "path/to/template.yaml"
     enable_caching = "invalid_value"

--- a/pipelines/variables/variables.yml
+++ b/pipelines/variables/variables.yml
@@ -1,6 +1,6 @@
-vertex_project_dev: "dt-theo-sandbox-dev"
-vertex_project_staging: "dt-theo-sandbox-staging"
-vertex_project_prod: "dt-theo-sandbox-prod"
+vertex_project_dev: "my-gcp-project-dev"
+vertex_project_staging: "my-gcp-project-staging"
+vertex_project_prod: "my-gcp-project-prod"
 
 dev:
   scheduler:

--- a/pipelines/variables/variables.yml
+++ b/pipelines/variables/variables.yml
@@ -1,0 +1,39 @@
+vertex_project_dev: "dt-theo-sandbox-dev"
+vertex_project_staging: "dt-theo-sandbox-staging"
+vertex_project_prod: "dt-theo-sandbox-prod"
+
+dev:
+  scheduler:
+    enable_training_scheduler: true
+    training_cron: "0 0 * * 4"  # https://crontab.guru/
+    training_max_concurrent_run_count: 1
+    training_max_run_count: 0  # Put 0 for infinite
+
+    enable_prediction_scheduler: false
+    prediction_cron: ""  # https://crontab.guru/
+    prediction_max_concurrent_run_count: 1
+    prediction_max_run_count: 0  # Put 0 for infinite
+
+staging:
+  scheduler:
+    enable_training_scheduler: false
+    training_cron: "0 0 * * 4"  # https://crontab.guru/
+    training_max_concurrent_run_count: 1
+    training_max_run_count: 0  # Put 0 for infinite
+
+    enable_prediction_scheduler: false
+    prediction_cron: ""  # https://crontab.guru/
+    prediction_max_concurrent_run_count: 1
+    prediction_max_run_count: 0  # Put 0 for infinite
+
+prod:
+  scheduler:
+    enable_training_scheduler: false
+    training_cron: "0 0 * * 4"  # https://crontab.guru/
+    training_max_concurrent_run_count: 1
+    training_max_run_count: 0  # Put 0 for infinite
+
+    enable_prediction_scheduler: false
+    prediction_cron: ""  # https://crontab.guru/
+    prediction_max_concurrent_run_count: 1
+    prediction_max_run_count: 0  # Put 0 for infinite

--- a/pipelines/variables/variables.yml
+++ b/pipelines/variables/variables.yml
@@ -4,7 +4,7 @@ vertex_project_prod: "dt-theo-sandbox-prod"
 
 dev:
   scheduler:
-    enable_training_scheduler: true
+    enable_training_scheduler: false
     training_cron: "0 0 * * 4"  # https://crontab.guru/
     training_max_concurrent_run_count: 1
     training_max_run_count: 0  # Put 0 for infinite


### PR DESCRIPTION
<!-- 
Copyright 2023 Google LLC

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    https://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
 -->
# Description

This PR adds support for scheduling pipelines using the Vertex AI PipelineJobSchedule API

What changed:

New reusable config loader (pipelines/src/pipelines/utils/load_config.py): Introduced detect_environment() and load_variables() functions. detect_environment() matches the VERTEX_PROJECT_ID env var against the vertex_project_dev, vertex_project_staging, and vertex_project_prod values in variables.yml to determine which environment the pipeline is running in. load_variables() parses variables.yml and returns the full config block for the detected environment. If no projects match, it returns none, and the scheduling part of the pipeline is skipped

Scheduling logic in trigger_pipeline.py: Added delete_previous_schedules() which removes any existing schedules matching a given display name, ensuring only one schedule exists per pipeline type. Added _handle_schedule() which reads the scheduler config from variables.yml (cron expression, max concurrent runs, max run count, enable flag) and either creates a new schedule via PipelineJob.create_schedule() or deletes existing ones if the scheduler is disabled. 

How it works:
Run the e2e pipelines with/without scheduling and it was creating it and destroying it successfully. Also, added a mock for load_variables in the existing tests so they don't hit the real YAML file and continue to pass.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`make test-trigger` and `make test-all-components`)
- [x] I have successfully run the E2E tests
- [x] I have updated any relevant documentation to reflect my changes
