### PR TITLE
docs: update legacy gsutil commands to gcloud storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,11 @@ Before your CI/CD pipelines can deploy the infrastructure, you will need to set 
 ```bash
 export DEV_PROJECT_ID=my-dev-gcp-project
 export DEV_LOCATION=europe-west2
-gsutil mb -l $DEV_LOCATION -p $DEV_PROJECT_ID --pap=enforced gs://$DEV_PROJECT_ID-tfstate && \
-  gsutil ubla set on gs://$DEV_PROJECT_ID-tfstate
+gcloud storage buckets create gs://$DEV_PROJECT_ID-tfstate \
+  --project=$DEV_PROJECT_ID \
+  --location=$DEV_LOCATION \
+  --uniform-bucket-level-access \
+  --public-access-prevention
 ```
 
 Enable APIs in admin project:

--- a/docs/Contribution.md
+++ b/docs/Contribution.md
@@ -68,7 +68,11 @@ storage.googleapis.com \
 Create a bucket to use for the Vertex Pipelines pipeline root.
 
 ```
-gsutil mb -l ${GCP_REGION} -p ${GCP_PROJECT_ID} --pap=enforced gs://${GCP_PROJECT_ID}-pl-root && gsutil ubla set on gs://${GCP_PROJECT_ID}-pl-root
+gcloud storage buckets create gs://${GCP_PROJECT_ID}-pl-root \
+  --project=${GCP_PROJECT_ID} \
+  --location=${GCP_REGION} \
+  --uniform-bucket-level-access \
+  --public-access-prevention
 ```
 
 ### Artifact Registry
@@ -142,9 +146,13 @@ gcloud projects add-iam-policy-binding $GCP_PROJECT_ID --member="serviceAccount:
 The Vertex Pipelines service account requires read/write/list access to the pipeline root bucket:
 
 ```
-gsutil iam ch serviceAccount:vertex-pipelines@${GCP_PROJECT_ID}.iam.gserviceaccount.com:objectAdmin gs://${GCP_PROJECT_ID}-pl-root
+gcloud storage buckets add-iam-policy-binding gs://${GCP_PROJECT_ID}-pl-root \
+  --member=serviceAccount:vertex-pipelines@${GCP_PROJECT_ID}.iam.gserviceaccount.com \
+  --role=roles/storage.objectAdmin
 
-gsutil iam ch serviceAccount:vertex-pipelines@${GCP_PROJECT_ID}.iam.gserviceaccount.com:legacyBucketReader gs://${GCP_PROJECT_ID}-pl-root
+gcloud storage buckets add-iam-policy-binding gs://${GCP_PROJECT_ID}-pl-root \
+  --member=serviceAccount:vertex-pipelines@${GCP_PROJECT_ID}.iam.gserviceaccount.com \
+  --role=roles/storage.legacyBucketReader
 ```
 
 ## Cloud Build setup

--- a/docs/notebooks/01_infrastructure_setup.ipynb
+++ b/docs/notebooks/01_infrastructure_setup.ipynb
@@ -223,7 +223,7 @@
             },
             "outputs": [],
             "source": [
-                "! source env.sh && gsutil mb -l $VERTEX_LOCATION -p $VERTEX_PROJECT_ID gs://$VERTEX_PROJECT_ID-tfstate"
+                "! source env.sh && gcloud storage buckets create gs://$VERTEX_PROJECT_ID-tfstate --project=$VERTEX_PROJECT_ID --location=$VERTEX_LOCATION"
             ]
         },
         {

--- a/docs/notebooks/03_infrastructure_cleanup.ipynb
+++ b/docs/notebooks/03_infrastructure_cleanup.ipynb
@@ -109,8 +109,8 @@
             "outputs": [],
             "source": [
                 "%%bash\n",
-                "gsutil rm -a gs://${VERTEX_PROJECT_ID}-staging/**\n",
-                "gsutil rm -a gs://${VERTEX_PROJECT_ID}-pl-root/**"
+                "gcloud storage rm --recursive --all-versions gs://${VERTEX_PROJECT_ID}-staging/**\n",
+                "gcloud storage rm --recursive --all-versions gs://${VERTEX_PROJECT_ID}-pl-root/**"
             ]
         },
         {


### PR DESCRIPTION
<!-- 
Copyright 2023 Google LLC

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    https://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
 -->
# Description

`gsutil` command is legacy and set for removal from Google Cloud CLI.

Update documentation to replace commands with `gcloud storage` equivalents, which is the recommended tool for these operations.

# How has this been tested?

Previously used `gcloud storage` commands when setting up turbo templates from scratch in dev sandbox.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas
- [-] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`make test-trigger` and `make test-all-components`)
- [-] I have successfully run the E2E tests
- [x] I have updated any relevant documentation to reflect my changes
