### PR TITLE
fix(docs): remove outdated poetry config

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@ It describes the scheduling of pipelines and how to tear down infrastructure.
 
 ```bash
 pyenv install --skip-existing 3.12.8                  # install Python 3.12.8
-poetry config virtualenvs.prefer-active-python true   # configure Poetry
 make install                                          # install Python dependencies
 cd pipelines && poetry run pre-commit install         # install pre-commit hooks
 cp env.sh.example env.sh


### PR DESCRIPTION
<!-- 
Copyright 2023 Google LLC

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    https://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
 -->
# Description

Poetry config setting `virtualenvs.prefer-active-python` was removed in poetry 2.0 (January 2025), and this setting is now the default behaviour.

(A new option `virtualenvs.use-poetry-python` has replaced it, with default False. This reverses the default/optional behaviour.)

See docs: https://python-poetry.org/blog/announcing-poetry-2.0.0/#changed-config-settings

# How has this been tested?

Running the previous command in Poetry >2.0 gives error.

# Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (`make test-trigger` and `make test-all-components`)
- [ ] I have successfully run the E2E tests
- [ ] I have updated any relevant documentation to reflect my changes
